### PR TITLE
Add Floyd-Steinberg dithering

### DIFF
--- a/src/utils/image/ciede2000.py
+++ b/src/utils/image/ciede2000.py
@@ -3,17 +3,37 @@ from numba import jit
 
 
 @jit(nopython=True, cache=True)
-def rgb2xyz(rgb):
-    """Converts RGB pixel array to XYZ format."""
-    rgb = rgb.astype(np.float64)
+def srgb2rgb(srgb):
+    """Converts sRGB pixel array to linear RGB format"""
     for i in range(3):
-        c = rgb[i]
-        c = c / 255.0
+        c = srgb[i]
         if c > 0.04045:
             c = ((c + 0.055) / 1.055) ** 2.4
         else:
             c = c / 12.92
-        rgb[i] = c * 100
+        srgb[i] = c
+    return srgb
+
+
+@jit(nopython=True, cache=True)
+def rgb2srgb(rgb):
+    """Converts linear RGB pixel array to sRGB format"""
+    srgb = rgb.astype(np.float64)
+    for i in range(3):
+        c = srgb[i]
+        if c > 0.0031308:
+            c = 1.055 * c ** (1 / 2.4) - 0.055
+        else:
+            c = c * 12.92
+        srgb[i] = c
+    return srgb
+
+
+@jit(nopython=True, cache=True)
+def rgb2xyz(rgb):
+    """Converts linear RGB pixel array to XYZ format."""
+    rgb = rgb.astype(np.float64)
+    rgb *= 100
     xyz = np.zeros((3), dtype=np.float64)
     xyz[0] = rgb[0] * 0.4124 + rgb[1] * 0.3576 + rgb[2] * 0.1805
     xyz[1] = rgb[0] * 0.2126 + rgb[1] * 0.7152 + rgb[2] * 0.0722

--- a/src/utils/pxls/template.py
+++ b/src/utils/pxls/template.py
@@ -212,7 +212,7 @@ def reduce(array: np.ndarray, palette: np.ndarray, colordist: ColorDist, dither:
     Parameters
     ----------
     array: a numpy array of 0-255 RGBA colors (shape (h, w, 4))
-    palette: a numpy array (shape (h, w, 1))
+    palette: a numpy array (shape (N, 3))
     colordist: the algorithm to use to match the colors
     dither: a 0-1 float indicating dithering strength
     """


### PR DESCRIPTION
This PR adds support for [Floyd Steinberg dithering](https://en.wikipedia.org/wiki/Floyd%E2%80%93Steinberg_dithering). The dithering is disabled by default, and you can specify its strength from `0` (disabled) to `1`.

The main changes outside of the dithering implementation itself are:
* Move to a 0-1 representation of colors in `reduce` and all colorspace conversion functions. This allows us to add a quantization error to a color without worrying about integer overflow or having to do type conversions twice a line.
* Differentiate sRGB and linear RGB colorspaces in the colorspace conversion functions. This is required for the dithering to not change the image's brightness ([more info on gamma-correct dithering here](https://www.nayuki.io/page/gamma-aware-image-dithering)).

