### PR TITLE
Update template.py - clean up / shorten discord template image

### DIFF
--- a/src/cogs/pxls_template/template.py
+++ b/src/cogs/pxls_template/template.py
@@ -421,7 +421,8 @@ class Template(commands.Cog):
                 template_image_url, img.width, img.height, ox, oy, title
             )
             # update the embed with the link in a new field
-            embed.set_thumbnail(url=template_image_url)
+                template_image_url = template_image_url.replace("media.discordapp.net", "cdn.discordapp.com").split('?')[0]
+                embed.set_thumbnail(url=template_image_url)
             embed.add_field(name="**Template Link**", value=template_url, inline=False)
             embed.set_footer(
                 text="⏲️ Generated in {}s | Uploaded in {}s".format(

--- a/src/cogs/pxls_template/template.py
+++ b/src/cogs/pxls_template/template.py
@@ -421,8 +421,8 @@ class Template(commands.Cog):
                 template_image_url, img.width, img.height, ox, oy, title
             )
             # update the embed with the link in a new field
-                template_image_url = template_image_url.replace("media.discordapp.net", "cdn.discordapp.com").split('?')[0]
-                embed.set_thumbnail(url=template_image_url)
+            template_image_url = template_image_url.replace("media.discordapp.net", "cdn.discordapp.com").split('?')[0]
+            embed.set_thumbnail(url=template_image_url)
             embed.add_field(name="**Template Link**", value=template_url, inline=False)
             embed.set_footer(
                 text="⏲️ Generated in {}s | Uploaded in {}s".format(


### PR DESCRIPTION
I made it get rid of unnecessary parameters in as well as replacing media.discordapp.net with cdn.discordapp.com Discord started adding tons of parameters which I read were to be used to make the links temporary to prevent people from using discord as a free image host. media.discordapp.net is a longer domain and its meant for thumbnails of images where cdn is for the original quality, cdn.discordapp.com is just better
I don't usually use python, idk if it works, and I am too lazy to test it. If not its a simple change and should be easily fixed if my code doesn't work.