### PR TITLE
Pxls.space CFAuth & Discord Intent Update

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -5,6 +5,7 @@ LOG_LEVEL = "INFO"  # the default log level for the console logs
 PXLS_URL = "https://pxls.space" # public pxls URL
 PXLS_URL_API = "https://pxls.space" # pxls URL for API calls
 PXLS_WEBSOCKET = "wss://pxls.space/ws"
+PXLS_CFAUTH = "" # required! you need to be approved for pxls.space api access
 
 # discord
 DISCORD_TOKEN = "1234.1234.1234"

--- a/src/main.py
+++ b/src/main.py
@@ -20,7 +20,8 @@ from utils.setup import (
 )
 
 load_dotenv()
-intents = disnake.Intents.all()
+intents = disnake.Intents(messages=True)
+intents.message_content = True
 activity = disnake.Activity(
     type=disnake.ActivityType.watching, name="you placing those pixels 👀"
 )

--- a/src/utils/pxls/websocket_client.py
+++ b/src/utils/pxls/websocket_client.py
@@ -41,7 +41,10 @@ class WebsocketClient:
 
         while True:
             pxls_validate = str(uuid.uuid4())
-            headers = {"Cookie": f"pxls-validate={pxls_validate}"}
+            headers = {
+                "Cookie": f"pxls-validate={pxls_validate}",
+                "x-pxls-cfauth": f"{pxls_cfauth}"
+            }
             try:
                 async with websockets.connect(
                     self.uri, extra_headers=headers

--- a/src/utils/pxls/websocket_client.py
+++ b/src/utils/pxls/websocket_client.py
@@ -14,9 +14,10 @@ class WebsocketClient:
     """A threaded websocket client to update the canvas board and online count
     in real-time."""
 
-    def __init__(self, uri: str, stats_manager):
+    def __init__(self, uri: str, stats_manager, cfauth):
         self.uri = uri
         self.stats = stats_manager
+        self.pxls_cfauth = cfauth
         self.loop = asyncio.new_event_loop()
         self.thread = threading.Thread(target=self._start, daemon=True)
         self._paused = False
@@ -43,7 +44,7 @@ class WebsocketClient:
             pxls_validate = str(uuid.uuid4())
             headers = {
                 "Cookie": f"pxls-validate={pxls_validate}",
-                "x-pxls-cfauth": f"{pxls_cfauth}"
+                "x-pxls-cfauth": f"{self.pxls_cfauth}"
             }
             try:
                 async with websockets.connect(

--- a/src/utils/setup.py
+++ b/src/utils/setup.py
@@ -30,7 +30,7 @@ PXLS_CFAUTH = os.getenv("PXLS_CFAUTH")
 db_conn = DbConnection()
 
 # connection with the pxls API
-stats = PxlsStatsManager(db_conn, PXLS_URL_API, PXLS_CFAUTH)
+stats = PxlsStatsManager(db_conn, PXLS_URL_API)
 
 # default prefix
 DEFAULT_PREFIX = ">"

--- a/src/utils/setup.py
+++ b/src/utils/setup.py
@@ -30,7 +30,7 @@ PXLS_CFAUTH = os.getenv("PXLS_CFAUTH")
 db_conn = DbConnection()
 
 # connection with the pxls API
-stats = PxlsStatsManager(db_conn, PXLS_URL_API)
+stats = PxlsStatsManager(db_conn, PXLS_URL_API, PXLS_CFAUTH)
 
 # default prefix
 DEFAULT_PREFIX = ">"
@@ -44,7 +44,7 @@ db_canvas = DbCanvasManager(db_conn)
 
 # websocket
 ws_uri = os.getenv("PXLS_WEBSOCKET")
-ws_client = WebsocketClient(ws_uri, stats)
+ws_client = WebsocketClient(ws_uri, stats, PXLS_CFAUTH)
 
 # guild IDs
 test_server_id = os.getenv("TEST_SERVER_ID")

--- a/src/utils/setup.py
+++ b/src/utils/setup.py
@@ -24,6 +24,7 @@ SERVER_INVITE = os.getenv("SERVER_INVITE")
 # pxls URLs
 PXLS_URL = os.getenv("PXLS_URL")
 PXLS_URL_API = os.getenv("PXLS_URL_API")
+PXLS_CFAUTH = os.getenv("PXLS_CFAUTH")
 
 # database connection
 db_conn = DbConnection()

--- a/src/utils/utils.py
+++ b/src/utils/utils.py
@@ -6,7 +6,7 @@ import functools
 import re
 import timeit
 from typing import Awaitable, Callable, Optional, TypeVar
-
+import uuid
 import aiohttp
 import numpy as np
 from aiohttp.client_exceptions import ClientConnectionError, InvalidURL
@@ -26,6 +26,11 @@ async def get_content(url: str, content_type, **kwargs):
     Raise BadResponseError or ValueError."""
     # check if the URL is a data URL
     data = check_data_url(url)
+    pxls_validate = str(uuid.uuid4())
+    headers = {
+        "Cookie": f"pxls-validate={pxls_validate}",
+        "x-pxls-cfauth": f"{pxls_cfauth}" # this auth can be found when you are approved for api access in pxls.space
+    }
     if data:
         return data
     timeout = aiohttp.ClientTimeout(
@@ -33,7 +38,7 @@ async def get_content(url: str, content_type, **kwargs):
     )  # set a timeout of 10 seconds
     async with aiohttp.ClientSession(timeout=timeout, **kwargs) as session:
         try:
-            async with session.get(url) as r:
+            async with session.get(url, headers=headers) as r:
                 if r.status == 200:
                     if content_type == "json":
                         return await r.json()

--- a/src/utils/utils.py
+++ b/src/utils/utils.py
@@ -12,6 +12,8 @@ import numpy as np
 from aiohttp.client_exceptions import ClientConnectionError, InvalidURL
 from typing_extensions import ParamSpec
 
+from dotenv import load_dotenv # this might be me being lazy but if it works, it works
+
 T = TypeVar("T")
 P = ParamSpec("P")
 _MaybeEventLoop = Optional[asyncio.AbstractEventLoop]
@@ -25,6 +27,7 @@ async def get_content(url: str, content_type, **kwargs):
     """Send a GET request to the url and return the response as json or bytes.
     Raise BadResponseError or ValueError."""
     # check if the URL is a data URL
+    pxls_cfauth = os.getenv("PXLS_CFAUTH")
     data = check_data_url(url)
     pxls_validate = str(uuid.uuid4())
     headers = {


### PR DESCRIPTION
When running Clueless for the first time with everything in env filled, there are 403 errors everywhere. 
This is because of an API change where if you don't have something called cfauth, it won't let you do anything. 

I went ahead and fixed the websocket and the stats manager by adding a header with the cfauth.
I also updated intents so that it uses only Message Content Intent rather than Intent.all (because that's all it needs) and I updated the env file to add the cfauth.

