### PR TITLE
Minor Imgur fix

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -20,7 +20,8 @@ from utils.setup import (
 )
 
 load_dotenv()
-intents = disnake.Intents.all()
+intents = disnake.Intents(messages=True)
+intents.message_content = True
 activity = disnake.Activity(
     type=disnake.ActivityType.watching, name="you placing those pixels 👀"
 )

--- a/src/utils/utils.py
+++ b/src/utils/utils.py
@@ -26,6 +26,15 @@ async def get_content(url: str, content_type, **kwargs):
     Raise BadResponseError or ValueError."""
     # check if the URL is a data URL
     data = check_data_url(url)
+    # set headers for user-agent
+    headers = {
+            'user-agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36'
+        }
+    if content_type == "image":
+        if url.startswith('https://imgur.com/'):
+            reurl = re.search(r'https://imgur\.com/([^?#]*)', url)
+            image_hash = reurl.group(1)
+            url = f"https://i.imgur.com/{image_hash}.png"
     if data:
         return data
     timeout = aiohttp.ClientTimeout(
@@ -33,7 +42,7 @@ async def get_content(url: str, content_type, **kwargs):
     )  # set a timeout of 10 seconds
     async with aiohttp.ClientSession(timeout=timeout, **kwargs) as session:
         try:
-            async with session.get(url) as r:
+            async with session.get(url, headers=headers) as r:
                 if r.status == 200:
                     if content_type == "json":
                         return await r.json()


### PR DESCRIPTION
**Fixes >template command not working for imgur links.** Additionally, this patch should work on most image or cdn image links too as it has a valid user-agent (Windows 10 Google Chrome).

Example of said fix:
![image](https://github.com/user-attachments/assets/e0f897a4-9519-4344-920b-ad8c2b02d20c)
_(The thumbnail on the embed is a bit broken at the moment due to my disnake or python versions.)_

Example of same command in current Clueless:
![image](https://github.com/user-attachments/assets/df53a2d0-5605-497d-8478-645e21634303)
